### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Simple answer: because there are other ways than HTTP requests to exploit
 SQLi vulnerabilities ! Most of the available tools only rely on HTTP GET/POST
 methods, and sometimes provide other methods. 
 
-PySQLi is thought to be easily modified and extended through derivated classes
+PySQLi is thought to be easily modified and extended through derived classes
 and to be able to inject into various ways such as command line, custom network
 protocols and even in anti-CSRF HTTP forms.
 

--- a/pysqli/core/context.py
+++ b/pysqli/core/context.py
@@ -91,7 +91,7 @@ class Context:
         """
         return self.__field_type
 
-    ## Enable SQL string encvoding
+    ## Enable SQL string encoding
     # Enable SQL string encoding to evade anti-quote functions or WAF
 
     def enable_string_encoding(self, enabled):
@@ -284,7 +284,7 @@ class Context:
         Set inband fields
         
         Inband fields are quite special: they are described with a single string
-        with these possible caracters:
+        with these possible characters:
             - s: specify a string field
             - i: specify an integer field
         


### PR DESCRIPTION
There are small typos in:
- README.md
- pysqli/core/context.py

Fixes:
- Should read `encoding` rather than `encvoding`.
- Should read `derived` rather than `derivated`.
- Should read `characters` rather than `caracters`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md